### PR TITLE
Fix: コメント保存形式を文字列配列に変更

### DIFF
--- a/src/server.cjs
+++ b/src/server.cjs
@@ -9,7 +9,8 @@ app.use(cors());//corsを許可
 
 const commentsDir = path.join(__dirname, "data");//現在のディレクトリを基準にdataディレクトリを追加
 const commentsPath = path.join(commentsDir, "comments.json");//jsonのパスを設定
-//初期化の処理
+
+// 初期化の処理
 if (!fs.existsSync(commentsDir)) {
 	fs.mkdirSync(commentsDir);//dataディレクトリが存在しない場合は作成
 }
@@ -18,19 +19,24 @@ if (fs.existsSync(commentsPath)) {
 	fs.unlinkSync(commentsPath); // あれば削除
 }
 
-fs.writeFileSync(commentsPath, "[]", "utf-8"); // 毎回空ファイルを新規作成
+// 初期値として空の "comments" 配列を含むオブジェクトを保存
+fs.writeFileSync(commentsPath, JSON.stringify({ comments: [] }, null, 2), "utf-8");
 
-
+// POST: コメントを追加
 app.post("/post-comments", (req, res) => {
-	const comments = JSON.parse(fs.readFileSync(commentsPath, "utf-8"));
-	comments.push(req.body);
-	fs.writeFileSync(commentsPath, JSON.stringify(comments, null, 2), "utf-8");
+	const data = JSON.parse(fs.readFileSync(commentsPath, "utf-8"));
+	data.comments.push(req.body.comment); // req.body は文字列
+	fs.writeFileSync(commentsPath, JSON.stringify(data, null, 2), "utf-8");
 	res.json(req.body);
 });
 
+// GET: コメント取得
 app.get("/get-comments", (req, res) => {
-	const comments = JSON.parse(fs.readFileSync(commentsPath, "utf-8"));
-	res.json(comments);
+	const data = fs.existsSync(commentsPath)
+		? JSON.parse(fs.readFileSync(commentsPath, "utf-8"))
+		: { comments: [] };
+
+	res.json(data.comments || []); // ← 配列だけ返す！
 });
 
 const PORT = process.env.PORT || 5000;


### PR DESCRIPTION
issue#30 .json保存時，全部のコメントのキーにcommentsキーがついているのを修正しました。